### PR TITLE
Change the definition of s-capitalize and add s-titleize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-downcase](#s-downcase-s) `(s)`
 * [s-upcase](#s-upcase-s) `(s)`
 * [s-capitalize](#s-capitalize-s) `(s)`
+* [s-titleize](#s-titleize-s) `(s)`
 * [s-with](#s-with-s-form-rest-more) `(s form &rest more)`
 * [s-index-of](#s-index-of-needle-s-optional-ignore-case) `(needle s &optional ignore-case)`
 * [s-reverse](#s-reverse-s) `(s)`
@@ -78,6 +79,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-snake-case](#s-snake-case-s) `(s)`
 * [s-dashed-words](#s-dashed-words-s) `(s)`
 * [s-capitalized-words](#s-capitalized-words-s) `(s)`
+* [s-titleized-words](#s-titleized-words-s) `(s)`
 
 ## Documentation and examples
 
@@ -441,12 +443,22 @@ This is a simple wrapper around the built-in `upcase`.
 
 ### s-capitalize `(s)`
 
+Convert the first word's first character to upper case and the rest to lower case in `s`.
+
+```cl
+(s-capitalize "abc DEF") ;; => "Abc def"
+(s-capitalize "abc.DEF") ;; => "Abc.def"
+```
+
+### s-titleize `(s)`
+
 Convert each word's first character to upper case and the rest to lower case in `s`.
 
 This is a simple wrapper around the built-in `capitalize`.
 
 ```cl
-(s-capitalize "abc DEF") ;; => "Abc Def"
+(s-titleize "abc DEF") ;; => "Abc Def"
+(s-titleize "abc.DEF") ;; => "Abc.Def"
 ```
 
 ### s-with `(s form &rest more)`
@@ -541,9 +553,19 @@ Convert `s` to dashed-words.
 Convert `s` to Capitalized Words.
 
 ```cl
-(s-capitalized-words "some words") ;; => "Some Words"
-(s-capitalized-words "under_scored_words") ;; => "Under Scored Words"
-(s-capitalized-words "camelCasedWords") ;; => "Camel Cased Words"
+(s-capitalized-words "some words") ;; => "Some words"
+(s-capitalized-words "under_scored_words") ;; => "Under scored words"
+(s-capitalized-words "camelCasedWords") ;; => "Camel cased words"
+```
+
+### s-titleized-words `(s)`
+
+Convert `s` to Titleized Words.
+
+```cl
+(s-titleized-words "some words") ;; => "Some Words"
+(s-titleized-words "under_scored_words") ;; => "Under Scored Words"
+(s-titleized-words "camelCasedWords") ;; => "Camel Cased Words"
 ```
 
 

--- a/examples.el
+++ b/examples.el
@@ -178,7 +178,12 @@
     (s-upcase "abc") => "ABC")
 
   (defexamples s-capitalize
-    (s-capitalize "abc DEF") => "Abc Def")
+    (s-capitalize "abc DEF") => "Abc def"
+    (s-capitalize "abc.DEF") => "Abc.def")
+
+  (defexamples s-titleize
+    (s-titleize "abc DEF") => "Abc Def"
+    (s-titleize "abc.DEF") => "Abc.Def")
 
   (defexamples s-with
     (s-with "   hulk smash   " s-trim s-upcase) => "HULK SMASH"
@@ -223,6 +228,11 @@
     (s-dashed-words "camelCasedWords") => "camel-cased-words")
 
   (defexamples s-capitalized-words
-    (s-capitalized-words "some words") => "Some Words"
-    (s-capitalized-words "under_scored_words") => "Under Scored Words"
-    (s-capitalized-words "camelCasedWords") => "Camel Cased Words"))
+    (s-capitalized-words "some words") => "Some words"
+    (s-capitalized-words "under_scored_words") => "Under scored words"
+    (s-capitalized-words "camelCasedWords") => "Camel cased words")
+
+  (defexamples s-titleized-words
+    (s-titleized-words "some words") => "Some Words"
+    (s-titleized-words "under_scored_words") => "Under Scored Words"
+    (s-titleized-words "camelCasedWords") => "Camel Cased Words"))

--- a/s.el
+++ b/s.el
@@ -270,6 +270,10 @@ This is a simple wrapper around the built-in `upcase'."
   (upcase s))
 
 (defun s-capitalize (s)
+  "Convert the first word's first character to upper case and the rest to lower case in S."
+  (concat (upcase (substring s 0 1)) (downcase (substring s 1))))
+
+(defun s-titleize (s)
   "Convert each word's first character to upper case and the rest to lower case in S.
 
 This is a simple wrapper around the built-in `capitalize'."
@@ -345,7 +349,12 @@ If it did not match the returned value is an empty list (nil)."
 
 (defun s-capitalized-words (s)
   "Convert S to Capitalized Words."
-  (s-join " " (mapcar 'capitalize (s-split-words s))))
+  (let ((words (s-split-words s)))
+    (s-join " " (cons (capitalize (car words)) (mapcar 'downcase (cdr words))))))
+
+(defun s-titleized-words (s)
+  "Convert S to Titleized Words."
+  (s-join " " (mapcar 's-titleize (s-split-words s))))
 
 (provide 's)
 ;;; s.el ends here


### PR DESCRIPTION
Hey,

Not sure what your opinion is about this, but mine differs from Emacs.

See for example:
https://github.com/rails/rails/blob/c7359e3267fd0a40da59152871a0a05307e98b3a/activesupport/lib/active_support/multibyte/chars.rb#L359
https://github.com/rails/rails/blob/c7359e3267fd0a40da59152871a0a05307e98b3a/activesupport/lib/active_support/multibyte/chars.rb#L368

Don't feel obligated to merge this at all. I guess It's a matter of taste, except that the capitalize function (my definition) will be missing if you don't merge it.
