### PR TITLE
s-match: support optional capture groups

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -111,7 +111,10 @@
     (s-match "^def" "abcdefg") => nil
     (s-match "^abc" "abcdefg") => '("abc")
     (s-match "^/.*/\\([a-z]+\\)\\.\\([a-z]+\\)" "/some/weird/file.html") => '("/some/weird/file.html" "file" "html")
-    (s-match "^/.*/\\([a-z]+\\)\\.\\([a-z]+\\)" "/some/weird/file.org") => '("/some/weird/file.org" "file" "org"))
+    (s-match "^/.*/\\([a-z]+\\)\\.\\([a-z]+\\)" "/some/weird/file.org") => '("/some/weird/file.org" "file" "org")
+    (s-match "^\\(abc\\)\\(def\\)?" "abcdef") => '("abcdef" "abc" "def")
+    (s-match "^\\(abc\\)\\(def\\)?" "abc") => '("abc" "abc")
+    (s-match "^\\(abc\\)\\(def\\)?\\(ghi\\)" "abcghi") => '("abcghi" "abc" nil "ghi"))
 
   (defexamples s-join
     (s-join "+" '("abc" "def" "ghi")) => "abc+def+ghi"

--- a/s.el
+++ b/s.el
@@ -312,9 +312,10 @@ If it did not match the returned value is an empty list (nil)."
       (let ((match-data-list (match-data))
             result)
         (while match-data-list
-          (let ((beg (car match-data-list))
-                (end (cadr match-data-list)))
-            (setq result (cons (substring s beg end) result))
+          (let* ((beg (car match-data-list))
+                 (end (cadr match-data-list))
+                 (subs (if (and beg end) (substring s beg end) nil)))
+            (setq result (cons subs result))
             (setq match-data-list
                   (cddr match-data-list))))
         (nreverse result))))


### PR DESCRIPTION
The values of match-data do not seem to support the ideal case. For the
test of "(abc)(def)?" matching against "abc", the most reasonable result
would be ("abc" "abc" nil); however, match-data provides no indication
of the second capture group.

Without this, though, s-match errors when match-data contains nils.
