### PR TITLE
Added `s-split' alias for `split-string'.

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -117,12 +117,12 @@
     (s-match "^\\(abc\\)\\(def\\)?\\(ghi\\)" "abcghi") => '("abcghi" "abc" nil "ghi"))
 
   (defexamples s-split
-    (s-split "a|bc|12|3" "|") => '("a" "bc" "12" "3")
-    (s-split "a,c,d" ":") => '("a,c,d")
-    (s-split "z\nefg\n" "\n") => '("z" "efg" "")
-    (s-split "z\nefg\n" "\n" t) => '("z" "efg")
-    (s-split "xyöözeföklmö" "ö") => '("xy" "" "zef" "klm" "")
-    (s-split "xyöözeföklmö" "ö" t) => '("xy" "zef" "klm"))
+    (s-split "|" "a|bc|12|3") => '("a" "bc" "12" "3")
+    (s-split ":" "a,c,d") => '("a,c,d")
+    (s-split "\n" "z\nefg\n") => '("z" "efg" "")
+    (s-split "\n" "z\nefg\n" t) => '("z" "efg")
+    (s-split "ö" "xyöözeföklmö") => '("xy" "" "zef" "klm" "")
+    (s-split "ö" "xyöözeföklmö" t) => '("xy" "zef" "klm"))
 
   (defexamples s-join
     (s-join "+" '("abc" "def" "ghi")) => "abc+def+ghi"

--- a/s.el
+++ b/s.el
@@ -56,7 +56,7 @@ This is a simple wrapper around the built-in `split-string'."
 
 (defun s-lines (s)
   "Splits S into a list of strings on newline characters."
-  (s-split s "\\(\r\n\\|[\n\r]\\)"))
+  (s-split "\\(\r\n\\|[\n\r]\\)" s))
 
 (defun s-join (separator strings)
   "Join all the strings in STRINGS with SEPARATOR in between."
@@ -335,9 +335,10 @@ If it did not match the returned value is an empty list (nil)."
 (defun s-split-words (s)
   "Split S into list of words."
   (s-split
+   "[^A-Za-z0-9]+"
    (let ((case-fold-search nil))
      (replace-regexp-in-string "\\([a-z]\\)\\([A-Z]\\)" "\\1 \\2" s))
-   "[^A-Za-z0-9]+" t))
+   t))
 
 (defun s--mapcar-head (fn-head fn-rest list)
   "Like MAPCAR, but applies a different function to the first element."


### PR DESCRIPTION
According to the "What's with the built-in wrappers?" section of the
README the API should be complete even if it simply wraps emacs
functionality.  Therefore an alias `s-split' for`split-string' should
exist.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
