### PR TITLE
s-match: START parameter

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -129,7 +129,9 @@
 
   (defexamples s-matches?
     (s-matches? "^[0-9]+$" "123") => t
-    (s-matches? "^[0-9]+$" "a123") => nil)
+    (s-matches? "^[0-9]+$" "a123") => nil
+    (s-matches? "1" "1a" 1) => nil
+    (s-matches? "1" "1a1" 1) => t)
 
   (defexamples s-blank?
     (s-blank? "") => t

--- a/s.el
+++ b/s.el
@@ -224,11 +224,12 @@ This is a simple wrapper around the built-in `string-equal'."
 
 (defalias 's-equals-p 's-equals?)
 
-(defun s-matches? (regexp s)
+(defun s-matches? (regexp s &optional start)
   "Does REGEXP match S?
+If START is non-nil the search starts at that index.
 
 This is a simple wrapper around the built-in `string-match-p'."
-  (s--truthy? (string-match-p regexp s)))
+  (s--truthy? (string-match-p regexp s start)))
 
 (defalias 's-matches-p 's-matches?)
 


### PR DESCRIPTION
string-match\* comes with a handy START parameter.  Sadly s-match\* does not support it.  And s-match should probably save external match-data or document the behavior.
