### PR TITLE
Package assoc.el is obsolete since emacs 24.2. Remove dependency

### DIFF
--- a/s.el
+++ b/s.el
@@ -27,8 +27,6 @@
 
 ;;; Code:
 
-(require 'assoc)
-
 (defun s-trim-left (s)
   "Remove whitespace at the beginning of S."
   (if (string-match "\\`[ \t\n\r]+" s)
@@ -286,10 +284,13 @@ This is a simple wrapper around the built-in `string-match-p'."
   "Replaces OLD with NEW in S."
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
+(defun s--aget (alist key)
+  (cdr (assoc key alist)))
+
 (defun s-replace-all (replacements s)
   "REPLACEMENTS is a list of cons-cells. Each `car` is replaced with `cdr` in S."
   (replace-regexp-in-string (regexp-opt (mapcar 'car replacements))
-                            (lambda (it) (aget replacements it))
+                            (lambda (it) (s--aget replacements it))
                             s))
 
 (defun s-downcase (s)
@@ -438,7 +439,7 @@ transformation."
                          ((eq replacer 'gethash)
                           (funcall replacer var extra))
                          ((eq replacer 'aget)
-                          (funcall replacer extra var))
+                          (funcall 's--aget extra var))
                          ((eq replacer 'elt)
                           (funcall replacer extra var))
                          (t


### PR DESCRIPTION
assoc.el is obsolete with emacs >= 24.2. My fix is just a small hack, especially in s-format. Maybe you can solve this better.
