### PR TITLE
Improvements to s-lex-format docstring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,17 +632,17 @@ transformation.
 
 ### s-lex-format `(format-str)`
 
-`s-format` with the lexical environment.
+`s-format` with the currently defined variables.
 
 `format-str` may use the `s-format` variable reference to refer to
-any lexical variable:
+any variable:
 
  (let ((x 1))
    (s-lex-format "x is: ${x}"))
 
-The values of the lexical variables are interpolated with "%s"
-unless the variable `s-lex-value-as-lisp` is `t` and then they
-are interpolated with "%S".
+The values of the variables are interpolated with "%s" unless
+the variable `s-lex-value-as-lisp` is `t` and then they are
+interpolated with "%S".
 
 ```cl
 (let ((x 1)) (s-lex-format "x is ${x}")) ;; => "x is 1"

--- a/s.el
+++ b/s.el
@@ -515,17 +515,17 @@ transformation."
                  (s-match-strings-all "${\\([^}]+\\)}" fmt)))))
 
 (defmacro s-lex-format (format-str)
-  "`s-format' with the lexical environment.
+  "`s-format` with the current environment.
 
 FORMAT-STR may use the `s-format' variable reference to refer to
-any lexical variable:
+any variable:
 
  (let ((x 1))
    (s-lex-format \"x is: ${x}\"))
 
-The values of the lexical variables are interpolated with \"%s\"
-unless the variable `s-lex-value-as-lisp' is `t' and then they
-are interpolated with \"%S\"."
+The values of the variables are interpolated with \"%s\" unless
+the variable `s-lex-value-as-lisp' is `t' and then they are
+interpolated with \"%S\"."
   (s-lex-fmt|expand format-str))
 
 (provide 's)


### PR DESCRIPTION
Just a change to the s-lex-format docstring, since it doesn't only apply to lexical variables.
