### PR TITLE
s-match-strings-all only considers non-overlapping strings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ When `start` is non-nil the search will start at that index.
 
 ### s-match-strings-all `(regex string)`
 
-Return a list of every match for `regex` in `string`.
+Return a list of every non-overlapping match for `regex` in `string`.
 
 Each element itself is a list of matches, as per `match-string`.
 
@@ -632,7 +632,7 @@ transformation.
 
 ### s-lex-format `(format-str)`
 
-`s-format` with the currently defined variables.
+`s-format` with the current environment.
 
 `format-str` may use the `s-format` variable reference to refer to
 any variable:

--- a/s.el
+++ b/s.el
@@ -353,7 +353,7 @@ attention to case differences."
   (apply 'string (nreverse (string-to-list s))))
 
 (defun s-match-strings-all (regex string)
-  "Return a list of every match for REGEX in STRING.
+  "Return a list of every non-overlapping match for REGEX in STRING.
 
 Each element itself is a list of matches, as per `match-string'."
   (let (all-strings


### PR DESCRIPTION
I feel this is worth mentioning in the docstring. I was surprised by the behaviour of:

```
(s-match-strings-all (rx (or "ab" "bb" "bc")) "abbc")
```
