### PR TITLE
Add `s-initials-words'

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-dashed-words](#s-dashed-words-s) `(s)`
 * [s-capitalized-words](#s-capitalized-words-s) `(s)`
 * [s-titleized-words](#s-titleized-words-s) `(s)`
+* [s-word-initials](#s-word-initials-s) `(s)`
 
 ## Documentation and examples
 
@@ -723,6 +724,16 @@ Convert `s` to Titleized Words.
 (s-titleized-words "some words") ;; => "Some Words"
 (s-titleized-words "under_scored_words") ;; => "Under Scored Words"
 (s-titleized-words "camelCasedWords") ;; => "Camel Cased Words"
+```
+
+### s-word-initials `(s)`
+
+Convert `s` to its initials.
+
+```cl
+(s-word-initials "some words") ;; => "sw"
+(s-word-initials "under_scored_words") ;; => "usw"
+(s-word-initials "camelCasedWords") ;; => "cCW"
 ```
 
 

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -371,4 +371,10 @@
   (defexamples s-titleized-words
     (s-titleized-words "some words") => "Some Words"
     (s-titleized-words "under_scored_words") => "Under Scored Words"
-    (s-titleized-words "camelCasedWords") => "Camel Cased Words"))
+    (s-titleized-words "camelCasedWords") => "Camel Cased Words")
+
+  (defexamples s-word-initials
+    (s-word-initials "some words") => "sw"
+    (s-word-initials "under_scored_words") => "usw"
+    (s-word-initials "camelCasedWords") => "cCW"
+    (s-word-initials "dashed-words") => "dw"))

--- a/s.el
+++ b/s.el
@@ -441,6 +441,10 @@ When START is non-nil the search will start at that index."
   "Convert S to Titleized Words."
   (s-join " " (mapcar 's-titleize (s-split-words s))))
 
+(defun s-word-initials (s)
+  "Convert S to its initials."
+  (s-join "" (mapcar (lambda (ss) (substring ss 0 1))
+                     (s-split-words s))))
 
 ;; Errors for s-format
 (progn


### PR DESCRIPTION
Add `s-initials-words' that take initials of a string. I thought I'd find it in 's but no. So here it is... 
