### PR TITLE
Add s-count-matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-presence](#s-presence-s) `(s)`
 * [s-format](#s-format-template-replacer-optional-extra) `(template replacer &optional extra)`
 * [s-lex-format](#s-lex-format-format-str) `(format-str)`
+* [s-count-matches](#s-count-matches-regexp-s-optional-start-end) `(regexp s &optional start end)`
 
 ### Pertaining to words
 
@@ -675,6 +676,19 @@ interpolated with "%S".
 (let ((x 1)) (s-lex-format "x is ${x}")) ;; => "x is 1"
 (let ((str1 "this") (str2 "that")) (s-lex-format "${str1} and ${str2}")) ;; => "this and that"
 (let ((foo "Hello\\nWorld")) (s-lex-format "${foo}")) ;; => "Hello\\nWorld"
+```
+
+### s-count-matches `(regexp s &optional start end)`
+
+Count occurrences of `regexp` in `s'.
+
+`start`, inclusive, and `end`, exclusive, delimit the part of `s`
+to match. 
+
+```cl
+(s-count-matches "a" "aba") ;; => 2
+(s-count-matches "a" "aba" 0 2) ;; => 1
+(s-count-matches "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") ;; => 2
 ```
 
 

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -341,7 +341,12 @@
     (let ((foo "Hello\\nWorld"))
       (s-lex-format "${foo}"))
     => "Hello\\nWorld"
-    ))
+    )
+
+  (defexamples s-count-matches
+    (s-count-matches "a" "aba") => 2
+    (s-count-matches "a" "aba" 0 2) => 1
+    (s-count-matches "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") => 2))
 
 (def-example-group "Pertaining to words"
   (defexamples s-split-words

--- a/s.el
+++ b/s.el
@@ -367,7 +367,7 @@ Each element itself is a list of matches, as per
 `match-string'. Multiple matches at the same position will be
 ignored after the first."
   (let ((all-strings ())
-  (i 0))
+        (i 0))
     (while (and (< i (length string))
                 (string-match regex string i))
       (setq i (1+ (match-beginning 0)))
@@ -541,6 +541,16 @@ The values of the variables are interpolated with \"%s\" unless
 the variable `s-lex-value-as-lisp' is `t' and then they are
 interpolated with \"%S\"."
   (s-lex-fmt|expand format-str))
+
+(defun s-count-matches (regexp s &optional start end)
+  "Count occurrences of `regexp' in `s'.
+
+`start', inclusive, and `end', exclusive, delimit the part of `s'
+to match. "
+  (with-temp-buffer
+    (insert s)
+    (goto-char (point-min))
+    (count-matches regexp (or start 1) (or end (point-max)))))
 
 (provide 's)
 ;;; s.el ends here


### PR DESCRIPTION
s-count-matches does the same as count-matches, but instead of counting
occurrences of regexp following point it takes a string argument.
