### PR TITLE
Fix s-reverse for Unicode combining characters.

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -282,7 +282,10 @@
   (defexamples s-reverse
     (s-reverse "abc") => "cba"
     (s-reverse "ab xyz") => "zyx ba"
-    (s-reverse "") => "")
+    (s-reverse "") => ""
+    (s-reverse "résumé") => "émusér"
+    ;; Two combining marks on a single character
+    (s-reverse "Ęyǫgwędę́hte⁷") => "⁷ethę́dęwgǫyĘ")
 
   (defexamples s-presence
     (s-presence nil) => nil


### PR DESCRIPTION
When reversing a Unicode string, care must be taken to reverse characters with their combining marks as a single unit, maintaining their order.
- https://github.com/mathiasbynens/esrever
- http://www.cl.cam.ac.uk/~mgk25/unicode.html

Before this patch, `s-reverse` does this (NFD normalized): 

``` el
(s-reverse "naïve")
;; => "ev̈ian"
```
