### PR TITLE
Update s-split documentation

### DIFF
--- a/s.el
+++ b/s.el
@@ -49,7 +49,7 @@
 
 (defun s-split (separator s &optional omit-nulls)
   "Split S into substrings bounded by matches for regexp SEPARATOR.
-If OMIT-NULLS is t, zero-length substrings are omitted.
+If OMIT-NULLS is non-nil, zero-length substrings are omitted.
 
 This is a simple wrapper around the built-in `split-string'."
   (split-string s separator omit-nulls))


### PR DESCRIPTION
The emacs documentation for split-string, which s-split wraps, is not correct:
"If OMIT-NULLS is t, zero-length substrings are omitted from the list (so
that for the default value of SEPARATORS leading and trailing whitespace
are effectively trimmed).  If nil, all zero-length substrings are retained,
which correctly parses CSV format, for example."

`omit-nulls` need not be `t`, it can be anything non-null:

```
...
  (let* ((keep-nulls (not (if separators omit-nulls t)))
...
```

This is useful to know if you prefer to use human-readable args, like `:omit-nulls` instead of `t`.
