### PR TITLE
Add s-wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-concat](#s-concat-rest-strings) `(&rest strings)`
 * [s-prepend](#s-prepend-prefix-s) `(prefix s)`
 * [s-append](#s-append-suffix-s) `(suffix s)`
+* [s-wrap](#s-wrap-left-right-s) `(left right s)`
 
 ### To and from lists
 
@@ -306,6 +307,16 @@ Concatenate `s` and `suffix`.
 
 ```cl
 (s-append "abc" "def") ;; => "defabc"
+```
+
+### s-wrap `(left right s)`
+
+Wrap `s` in strings `left` and `right`.
+
+```cl
+(s-wrap "[" "]" "foobar") ;; => "[foobar]"
+(s-wrap "(" "" "foobar") ;; => "(foobar"
+(s-wrap "" ")" "foobar") ;; => "foobar)"
 ```
 
 

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -109,7 +109,12 @@
     (s-prepend "abc" "def") => "abcdef")
 
   (defexamples s-append
-    (s-append "abc" "def") => "defabc"))
+    (s-append "abc" "def") => "defabc")
+
+  (defexamples s-wrap
+    (s-wrap "[" "]" "foobar") => "[foobar]"
+    (s-wrap "(" "" "foobar") => "(foobar"
+    (s-wrap "" ")" "foobar") => "foobar)"))
 
 (def-example-group "To and from lists"
   (defexamples s-lines

--- a/s.el
+++ b/s.el
@@ -102,6 +102,10 @@ See also `s-split'."
   "Concatenate S and SUFFIX."
   (concat s suffix))
 
+(defun s-wrap (left right s)
+  "Wrap S in strings LEFT and RIGHT."
+  (concat left s right))
+
 (defun s-repeat (num s)
   "Make a string of S repeated NUM times."
   (let (ss)


### PR DESCRIPTION
Wraps string with left anr right string. It's like `s-prepend` and `s-append` combined. Useful for creating "wrapping" combinators with `-partial`:

    (-map (-partial 's-wrap "[" "]") '("lots" "of" "words" "to" "wrap"))

gives

    '("[lots]" "[of]" "[words]" "[to]" "[wrap]")