### PR TITLE
Add s-wrap function

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-format](#s-format-template-replacer-optional-extra) `(template replacer &optional extra)`
 * [s-lex-format](#s-lex-format-format-str) `(format-str)`
 * [s-count-matches](#s-count-matches-regexp-s-optional-start-end) `(regexp s &optional start end)`
+* [s-wrap](#s-wrap-s-prefix-optional-suffix) `(s prefix &optional suffix)`
 
 ### Pertaining to words
 
@@ -704,6 +705,20 @@ to match.
 (s-count-matches "a" "aba") ;; => 2
 (s-count-matches "a" "aba" 0 2) ;; => 1
 (s-count-matches "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") ;; => 2
+```
+
+### s-wrap `(s prefix &optional suffix)`
+
+Wrap string `s` with `prefix` and optionally `suffix`.
+
+Return string `s` with `prefix` prepended.  If `suffix` is present, it
+is appended, otherwise `prefix` is used as both prefix and
+suffix.
+
+```cl
+(s-wrap "foo" "\"") ;; => "\"foo\""
+(s-wrap "foo" "(" ")") ;; => "(foo)"
+(s-wrap "foo" "bar") ;; => "barfoobar"
 ```
 
 

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -361,7 +361,12 @@
   (defexamples s-count-matches
     (s-count-matches "a" "aba") => 2
     (s-count-matches "a" "aba" 0 2) => 1
-    (s-count-matches "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") => 2))
+    (s-count-matches "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") => 2)
+
+  (defexamples s-wrap
+    (s-wrap "foo" "\"") => "\"foo\""
+    (s-wrap "foo" "(" ")") => "(foo)"
+    (s-wrap "foo" "bar") => "barfoobar"))
 
 (def-example-group "Pertaining to words"
   (defexamples s-split-words

--- a/s.el
+++ b/s.el
@@ -592,5 +592,13 @@ to match. "
     (goto-char (point-min))
     (count-matches regexp (or start 1) (or end (point-max)))))
 
+(defun s-wrap (s prefix &optional suffix)
+  "Wrap string S with PREFIX and optionally SUFFIX.
+
+Return string S with PREFIX prepended.  If SUFFIX is present, it
+is appended, otherwise PREFIX is used as both prefix and
+suffix."
+  (concat prefix s (or suffix prefix)))
+
 (provide 's)
 ;;; s.el ends here


### PR DESCRIPTION
Hey,

You really don't have to merge this unless you want to. I wrote a function where I wanted to wrap a string in quotes:

``` lisp
(concat "\"" string "\"")
```

I didn't like the look of it so I figured I'd write `s-wrap`. But again, if you don't like this, don't merge it! :)
