### PR TITLE
Add undercover support for Emacs 24+ to report coverage to coveralls.io

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,1 +1,8 @@
+(source gnu)
+(source melpa)
+
 (package-file "s.el")
+
+(development
+ (depends-on "undercover"))
+

--- a/dev/undercover-init.el
+++ b/dev/undercover-init.el
@@ -1,0 +1,2 @@
+(when (require 'undercover nil t)
+  (undercover "s.el"))

--- a/run-travis-ci.sh
+++ b/run-travis-ci.sh
@@ -17,4 +17,12 @@ echo "EMACS =" $(which $EMACS)
 $EMACS --version
 echo
 
-exec ./run-tests.sh
+if [ "$EMACS" != "emacs23" ]; then
+  curl -fsSLo /tmp/cask-master.zip https://github.com/cask/cask/archive/master.zip
+  sudo unzip -qq -d /opt /tmp/cask-master.zip
+  sudo ln -sf /opt/cask-master/bin/cask /usr/local/bin/cask
+  cask
+  cask exec $EMACS -batch -l dev/ert.el -l dev/examples-to-tests.el -l dev/undercover-init.el -l s.el -l dev/examples.el -f ert-run-tests-batch-and-exit
+else
+  exec ./run-tests.sh
+fi


### PR DESCRIPTION
This lets you display code coverage as a badge (~100%, wow!) that links to more detail. If you enable coverage reporting for your Github repository at coveralls.io, it'll get the information from Travis CI and give you the Markdown for the badge. Hope this is useful!