### PR TITLE
Remove duplicates s-wrap tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-concat](#s-concat-rest-strings) `(&rest strings)`
 * [s-prepend](#s-prepend-prefix-s) `(prefix s)`
 * [s-append](#s-append-suffix-s) `(suffix s)`
-* [s-wrap](#s-wrap-s-prefix-optional-suffix) `(s prefix &optional suffix)`
 
 ### To and from lists
 
@@ -309,21 +308,6 @@ Concatenate `s` and `suffix`.
 ```cl
 (s-append "abc" "def") ;; => "defabc"
 ```
-
-### s-wrap `(s prefix &optional suffix)`
-
-Wrap string `s` with `prefix` and optionally `suffix`.
-
-Return string `s` with `prefix` prepended.  If `suffix` is present, it
-is appended, otherwise `prefix` is used as both prefix and
-suffix.
-
-```cl
-(s-wrap "[" "]" "foobar") ;; => "[foobar]"
-(s-wrap "(" "" "foobar") ;; => "(foobar"
-(s-wrap "" ")" "foobar") ;; => "foobar)"
-```
-
 
 ### s-lines `(s)`
 

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -109,12 +109,7 @@
     (s-prepend "abc" "def") => "abcdef")
 
   (defexamples s-append
-    (s-append "abc" "def") => "defabc")
-
-  (defexamples s-wrap
-    (s-wrap "[" "]" "foobar") => "[foobar]"
-    (s-wrap "(" "" "foobar") => "(foobar"
-    (s-wrap "" ")" "foobar") => "foobar)"))
+    (s-append "abc" "def") => "defabc"))
 
 (def-example-group "To and from lists"
   (defexamples s-lines


### PR DESCRIPTION
Sorry, #79 changes are not enough. I forget to remove tests and documentation of `s-wrap`.