### PR TITLE
Fix s-slice-at for empty strings or non-consuming regexps

### DIFF
--- a/s.el
+++ b/s.el
@@ -440,13 +440,14 @@ When START is non-nil the search will start at that index."
 
 (defun s-slice-at (regexp s)
   "Slices S up at every index matching REGEXP."
-  (save-match-data
-    (let (i)
-      (setq i (string-match regexp s 1))
-      (if i
-          (cons (substring s 0 i)
-                (s-slice-at regexp (substring s i)))
-        (list s)))))
+  (unless (string-empty-p s)
+    (save-match-data
+      (let (i)
+        (setq i (string-match regexp s 1))
+        (if i
+            (cons (substring s 0 i)
+                  (s-slice-at regexp (substring s i)))
+          (list s))))))
 
 (defun s-split-words (s)
   "Split S into list of words."


### PR DESCRIPTION
I've just wrapped the function body with
`(unless (string-empty-p s) ...`

The following now works without errors:
`(s-slice-at "." "") ; => nil`
`(s-slice-at "\\>" "a") ; => ("a")`

