### PR TITLE
Add s-matched-positions-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-lines](#s-lines-s) `(s)`
 * [s-match](#s-match-regexp-s-optional-start) `(regexp s &optional start)`
 * [s-match-strings-all](#s-match-strings-all-regex-string) `(regex string)`
+* [s-matched-positions-all](#s-matched-positions-all-regexp-string-optional-subexp-depth) `(regexp string &optional subexp-depth)`
 * [s-slice-at](#s-slice-at-regexp-s) `(regexp s)`
 * [s-split](#s-split-separator-s-optional-omit-nulls) `(separator s &optional omit-nulls)`
 * [s-split-up-to](#s-split-up-to-separator-s-n-optional-omit-nulls) `(separator s n &optional omit-nulls)`
@@ -361,6 +362,17 @@ ignored after the first.
 (s-match-strings-all "{\\([^}]+\\)}" "x is {x} and y is {y}") ;; => '(("{x}" "x") ("{y}" "y"))
 (s-match-strings-all "ab." "abXabY") ;; => '(("abX") ("abY"))
 (s-match-strings-all "\\<" "foo bar baz") ;; => '(("") ("") (""))
+```
+
+### s-matched-positions-all `(regexp string &optional subexp-depth)`
+
+Return a list of matched positions for `regexp` in `string`.
+`subexp-depth` is 0 by default.
+
+```cl
+(s-matched-positions-all "l+" "{{Hello}} World, {{Emacs}}!" 0) ;; => '((4 . 6) (13 . 14))
+(s-matched-positions-all "{{\\(.+?\\)}}" "{{Hello}} World, {{Emacs}}!" 0) ;; => '((0 . 9) (17 . 26))
+(s-matched-positions-all "{{\\(.+?\\)}}" "{{Hello}} World, {{Emacs}}!" 1) ;; => '((2 . 7) (19 . 24))
 ```
 
 ### s-slice-at `(regexp s)`

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -136,8 +136,15 @@
   (defexamples s-match-strings-all
     (s-match-strings-all
      "{\\([^}]+\\)}" "x is {x} and y is {y}") => '(("{x}" "x") ("{y}" "y"))
-    (s-match-strings-all "ab." "abXabY") => '(("abX") ("abY"))
-    (s-match-strings-all "\\<" "foo bar baz") => '(("") ("") ("")))
+     (s-match-strings-all "ab." "abXabY") => '(("abX") ("abY"))
+     (s-match-strings-all "\\<" "foo bar baz") => '(("") ("") ("")))
+
+  (defexamples s-matched-positions-all
+    (s-matched-positions-all "l+"          "{{Hello}} World, {{Emacs}}!" 0) => '((4 . 6) (13 . 14))
+    (s-matched-positions-all "{{\\(.+?\\)}}" "{{Hello}} World, {{Emacs}}!" 0) => '((0 . 9) (17 . 26))
+    (s-matched-positions-all "{{\\(.+?\\)}}" "{{Hello}} World, {{Emacs}}!" 1) => '((2 . 7) (19 . 24))
+    (s-matched-positions-all "l"           "{{Hello}} World, {{Emacs}}!" 0) => '((4 . 5) (5 . 6) (13 . 14))
+    (s-matched-positions-all "abc"         "{{Hello}} World, {{Emacs}}!") => nil)
 
   (defexamples s-slice-at
     (s-slice-at "-" "abc") => '("abc")

--- a/s.el
+++ b/s.el
@@ -419,6 +419,19 @@ ignored after the first."
         (push (nreverse strings) all-strings)))
     (nreverse all-strings)))
 
+(defun s-matched-positions-all (regexp string &optional subexp-depth)
+  "Return a list of matched positions for REGEXP in STRING.
+SUBEXP-DEPTH is 0 by default."
+  (if (null subexp-depth)
+      (setq subexp-depth 0))
+  (let ((pos 0) result)
+    (while (and (string-match regexp string pos)
+                (< pos (length string)))
+      (let ((m (match-end subexp-depth)))
+        (push (cons (match-beginning subexp-depth) (match-end subexp-depth)) result)
+        (setq pos m)))
+    (nreverse result)))
+
 (defun s-match (regexp s &optional start)
   "When the given expression matches the string, this function returns a list
 of the whole matching string and a string for each matched subexpressions.


### PR DESCRIPTION
I add this because when I'm writing Emacs plugins, I found this is very commonly used for functions like `add-text-properties`. I use this in my [tldr.el](https://github.com/kuanyui/tldr.el) & new [moedict.el](https://github.com/kuanyui/moedict.el) (under progressing)