### PR TITLE
Fix wrong behavior in s-matched-positions-all 

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -144,7 +144,9 @@
     (s-matched-positions-all "{{\\(.+?\\)}}" "{{Hello}} World, {{Emacs}}!" 0) => '((0 . 9) (17 . 26))
     (s-matched-positions-all "{{\\(.+?\\)}}" "{{Hello}} World, {{Emacs}}!" 1) => '((2 . 7) (19 . 24))
     (s-matched-positions-all "l"           "{{Hello}} World, {{Emacs}}!" 0) => '((4 . 5) (5 . 6) (13 . 14))
-    (s-matched-positions-all "abc"         "{{Hello}} World, {{Emacs}}!") => nil)
+    (s-matched-positions-all "abc"         "{{Hello}} World, {{Emacs}}!") => nil
+    (s-matched-positions-all "=\\(.+?\\)=" "=Hello= World, =Emacs=!" 0) => '((0 . 7) (15 . 22))
+    (s-matched-positions-all "=\\(.+?\\)=" "=Hello= World, =Emacs=!" 1) => '((1 . 6) (16 . 21)))
 
   (defexamples s-slice-at
     (s-slice-at "-" "abc") => '("abc")

--- a/s.el
+++ b/s.el
@@ -429,7 +429,7 @@ SUBEXP-DEPTH is 0 by default."
                 (< pos (length string)))
       (let ((m (match-end subexp-depth)))
         (push (cons (match-beginning subexp-depth) (match-end subexp-depth)) result)
-        (setq pos m)))
+        (setq pos (match-end 0))))
     (nreverse result)))
 
 (defun s-match (regexp s &optional start)


### PR DESCRIPTION
Sorry :sweat: , I found a wrong behavior in my `s-matched-positions-all`, which cause possible duplicated matches when `subexp-depth` >= 1. Now fixed.
```lisp
;; Old version:
(s-matched-positions-all "=\\(.+?\\)=" "This is a =very= simple =sample=." 1) ;=> ((11 . 15) (16 . 24) (25 . 31))
;; New version:
(s-matched-positions-all "=\\(.+?\\)=" "This is a =very= simple =sample=." 1) ; => ((11 . 15) (25 . 31))
```