### PR TITLE
Make s-slice-at behave consistently on "".

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -150,7 +150,8 @@
     (s-slice-at "-" "abc") => '("abc")
     (s-slice-at "-" "abc-def") => '("abc" "-def")
     (s-slice-at "[\.#]" "abc.def.ghi#id") => '("abc" ".def" ".ghi" "#id")
-    (s-slice-at "-" "abc-def-") => '("abc" "-def" "-"))
+    (s-slice-at "-" "abc-def-") => '("abc" "-def" "-")
+    (s-slice-at "-" "") => '(""))
 
   (defexamples s-split
     (s-split "|" "a|bc|12|3") => '("a" "bc" "12" "3")

--- a/s.el
+++ b/s.el
@@ -453,13 +453,14 @@ When START is non-nil the search will start at that index."
 
 (defun s-slice-at (regexp s)
   "Slices S up at every index matching REGEXP."
-  (save-match-data
-    (let (i)
-      (setq i (string-match regexp s 1))
-      (if i
-          (cons (substring s 0 i)
-                (s-slice-at regexp (substring s i)))
-        (list s)))))
+  (if (= 0 (length s)) (list "")
+    (save-match-data
+      (let (i)
+        (setq i (string-match regexp s 1))
+        (if i
+            (cons (substring s 0 i)
+                  (s-slice-at regexp (substring s i)))
+          (list s))))))
 
 (defun s-split-words (s)
   "Split S into list of words."


### PR DESCRIPTION
Right now it just errors, but I think it is logical to return a list with an empty string, just like on `(s-slice-at "-" "abc")` it returns `("abc")` (that is, the string wrapped in a list).