### PR TITLE
modify the `s--aget'

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -309,7 +309,7 @@
     (s-presence "foo") => "foo")
 
   (defexamples s-format
-     ;; One with an alist works
+    ;; One with an alist works
     (s-format
      "help ${name}! I'm ${malady}"
      'aget
@@ -330,6 +330,13 @@
      'gethash
      #s(hash-table test equal data ("name" "nic" "malady" "on fire")))
     => "help nic! I'm on fire"
+
+    ;; Don't have to be string
+    (s-format "I'm ${name}, ${sex}, ${age} years old"
+              'aget
+              '((name . "Nick") (sex . male) (age . 2)))
+    => "I'm Nick, male, 2 years old"
+
 
     ;; Replacing case has no effect on s-format
     (let ((case-replace t))

--- a/s.el
+++ b/s.el
@@ -333,7 +333,7 @@ This is a simple wrapper around the built-in `string-match-p'."
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
 (defun s--aget (alist key)
-  (let ((result (cdr (assoc key alist))))
+  (let ((result (cdr (assoc-string key alist))))
     (when result
       (format "%s" result))))
 

--- a/s.el
+++ b/s.el
@@ -333,7 +333,7 @@ This is a simple wrapper around the built-in `string-match-p'."
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
 (defun s--aget (alist key)
-  (cdr (assoc key alist)))
+  (cdr (assoc-string key alist)))
 
 (defun s-replace-all (replacements s)
   "REPLACEMENTS is a list of cons-cells. Each `car` is replaced with `cdr` in S."

--- a/s.el
+++ b/s.el
@@ -333,7 +333,7 @@ This is a simple wrapper around the built-in `string-match-p'."
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
 (defun s--aget (alist key)
-  (cdr (assoc-string key alist)))
+  (format "%s" (cdr (assoc-string key alist))))
 
 (defun s-replace-all (replacements s)
   "REPLACEMENTS is a list of cons-cells. Each `car` is replaced with `cdr` in S."

--- a/s.el
+++ b/s.el
@@ -333,7 +333,9 @@ This is a simple wrapper around the built-in `string-match-p'."
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
 (defun s--aget (alist key)
-  (format "%s" (cdr (assoc-string key alist))))
+  (let ((result (cdr (assoc key alist))))
+    (when result
+      (format "%s" result))))
 
 (defun s-replace-all (replacements s)
   "REPLACEMENTS is a list of cons-cells. Each `car` is replaced with `cdr` in S."


### PR DESCRIPTION
It seems the `s--aget` function will always accept a string as the `KEY' parameter and should always return a string result or nil