### PR TITLE
Preserve text properties.

### DIFF
--- a/dev/examples-to-tests.el
+++ b/dev/examples-to-tests.el
@@ -3,7 +3,7 @@
 (defun examples-to-should-1 (examples)
   (let ((actual (car examples))
         (expected (cadr (cdr examples))))
-    `(should (equal ,actual ,expected))))
+    `(should (equal-including-properties ,actual ,expected))))
 
 (defun examples-to-should (examples)
   (let (result)

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -32,7 +32,8 @@
   (defexamples s-word-wrap
     (s-word-wrap 10 "This is too long") => "This is\ntoo long"
     (s-word-wrap 10 "This is way way too long") => "This is\nway way\ntoo long"
-    (s-word-wrap 10 "It-wraps-words-but-does-not-break-them") => "It-wraps-words-but-does-not-break-them")
+    (s-word-wrap 10 "It-wraps-words-but-does-not-break-them") => "It-wraps-words-but-does-not-break-them"
+    (s-word-wrap 100 (propertize "foo bar" 'face 'font-lock-keyword-face)) => (propertize "foo bar" 'face 'font-lock-keyword-face))
 
   (defexamples s-center
     (s-center 5 "a") => "  a  "
@@ -171,7 +172,8 @@
     (s-split-up-to "|" "foo||bar|baz|qux" 10 t) => '("foo" "bar" "baz" "qux")
     (s-split-up-to "|" "foo|bar|baz|" 2) => '("foo" "bar" "baz|")
     (s-split-up-to "|" "foo|bar|baz|" 2 t) => '("foo" "bar" "baz|")
-    (s-split-up-to "|" "foo|bar|baz|qux|" 2) => '("foo" "bar" "baz|qux|"))
+    (s-split-up-to "|" "foo|bar|baz|qux|" 2) => '("foo" "bar" "baz|qux|")
+    (s-split-up-to "|" (propertize "foo" 'face 'font-lock-keyword-face) 1) => (list (propertize "foo" 'face 'font-lock-keyword-face)))
 
   (defexamples s-join
     (s-join "+" '("abc" "def" "ghi")) => "abc+def+ghi"

--- a/s.el
+++ b/s.el
@@ -70,13 +70,13 @@ See also `s-split'."
         (setq op (goto-char (point-min)))
         (while (and (re-search-forward separator nil t)
                     (< 0 n))
-          (let ((sub (buffer-substring-no-properties op (match-beginning 0))))
+          (let ((sub (buffer-substring op (match-beginning 0))))
             (unless (and omit-nulls
                          (equal sub ""))
               (push sub r)))
           (setq op (goto-char (match-end 0)))
           (setq n (1- n)))
-        (let ((sub (buffer-substring-no-properties op (point-max))))
+        (let ((sub (buffer-substring op (point-max))))
           (unless (and omit-nulls
                        (equal sub ""))
             (push sub r))))
@@ -184,7 +184,7 @@ See also `s-split'."
     (insert s)
     (let ((fill-column len))
       (fill-region (point-min) (point-max)))
-    (buffer-substring-no-properties (point-min) (point-max))))
+    (buffer-substring (point-min) (point-max))))
 
 (defun s-center (len s)
   "If S is shorter than LEN, pad it with spaces so it is centered."


### PR DESCRIPTION
If we're given a string with properties, ensure the output has the same
properties.

This would be very useful for me, as I often want to `s-word-wrap` on a string that I've carefully propertized so the user sees it in colour. Using `buffer-substring` is often a good thing, but with `with-temp-buffer` no new properties are added anyway, so I believe this change is reasonable.

What do you think?