### PR TITLE
Add `s-splice`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-concat](#s-concat-rest-strings) `(&rest strings)`
 * [s-prepend](#s-prepend-prefix-s) `(prefix s)`
 * [s-append](#s-append-suffix-s) `(suffix s)`
+* [s-splice](#s-splice-needle-n-s) `(needle n s)`
 
 ### To and from lists
 
@@ -98,6 +99,7 @@ Or you can just dump `s.el` in your load path somewhere.
 * [s-capitalized-words](#s-capitalized-words-s) `(s)`
 * [s-titleized-words](#s-titleized-words-s) `(s)`
 * [s-word-initials](#s-word-initials-s) `(s)`
+* [s-blank-str?](#s-blank-str-s) `(s)`
 
 ## Documentation and examples
 
@@ -309,6 +311,18 @@ Concatenate `s` and `suffix`.
 ```cl
 (s-append "abc" "def") ;; => "defabc"
 ```
+
+### s-splice `(needle n s)`
+
+Splice `needle` into `s` at position `n`.
+0 is the beginning of the string, -1 is the end.
+
+```cl
+(s-splice "abc" 0 "def") ;; => "abcdef"
+(s-splice "abc" -1 "def") ;; => "defabc"
+(s-splice "needle" 2 "A  in a haystack.") ;; => "A needle in a haystack."
+```
+
 
 ### s-lines `(s)`
 
@@ -811,6 +825,16 @@ Convert `s` to its initials.
 (s-word-initials "some words") ;; => "sw"
 (s-word-initials "under_scored_words") ;; => "usw"
 (s-word-initials "camelCasedWords") ;; => "cCW"
+```
+
+### s-blank-str? `(s)`
+
+Is `s` nil or the empty string or string only contains whitespace?
+
+```cl
+(s-blank-str? "  \t \r   ") ;; => t
+(s-blank-str? "    ") ;; => t
+(s-blank-str? "\t\r") ;; => t
 ```
 
 

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -110,7 +110,12 @@
     (s-prepend "abc" "def") => "abcdef")
 
   (defexamples s-append
-    (s-append "abc" "def") => "defabc"))
+    (s-append "abc" "def") => "defabc")
+
+  (defexamples s-splice
+    (s-splice "abc" 0 "def") => "abcdef"
+    (s-splice "abc" -1 "def") => "defabc"
+    (s-splice "needle" 2 "A  in a haystack.") => "A needle in a haystack."))
 
 (def-example-group "To and from lists"
   (defexamples s-lines

--- a/s.el
+++ b/s.el
@@ -105,6 +105,18 @@ See also `s-split'."
   "Concatenate S and SUFFIX."
   (concat s suffix))
 
+(defun s-splice (needle n s)
+  "Splice NEEDLE into S at position N.
+0 is the beginning of the string, -1 is the end."
+  (if (< n 0)
+      (let ((left (substring s 0 (+ 1 n (length s))))
+            (right (s-right (- -1 n) s)))
+        (concat left needle right))
+    (let ((left (s-left n s))
+          (right (substring s n (length s))))
+        (concat left needle right))))
+
+
 (defun s-repeat (num s)
   "Make a string of S repeated NUM times."
   (let (ss)


### PR DESCRIPTION
`(s-splice NEEDLE N S)`

Splice `NEEDLE` into `S` at position `N`.
`0` is the beginning of the string, `-1` is the end.

For example:
```el
    (s-splice "abc" 0 "def") ; => "abcdef"
    (s-splice "abc" -1 "def") ; => "defabc"
    (s-splice "needle" 2 "A  in a haystack.") ; => "A needle in a haystack."
```

`s-splice` is actually a generalisation of `s-append` and `s-prepend`: you could define them as
```el
(require 'dash)
(defalias 's-prepend (-cut #'s-splice <> 0 <>)) ; you could use (-npartial 1 #'s-splice)
(defalias 's-append (-cut #'s-splice <> -1 <>)) ; instead of -cut...

```
(if it wasn't for *efficiency*).

----------------------

**NOTE:** it looks like @aborn forgot to build the docs for `s-blank-str?', so those have also been added in this commit. If this is a problem, it's no trouble for me to remove them, 