### PR TITLE
Conditionally require ucs-normalize

### DIFF
--- a/s.el
+++ b/s.el
@@ -27,8 +27,6 @@
 
 ;;; Code:
 
-(require 'ucs-normalize)
-
 (defun s-trim-left (s)
   "Remove whitespace at the beginning of S."
   (save-match-data
@@ -380,7 +378,8 @@ attention to case differences."
   "Return the reverse of S."
   (if (multibyte-string-p s)
       (let ((input (string-to-list s))
-            (output ()))
+            output)
+        (require 'ucs-normalize)
         (while input
           ;; Handle entire grapheme cluster as a single unit
           (let ((grapheme (list (pop input))))

--- a/s.el
+++ b/s.el
@@ -27,6 +27,10 @@
 
 ;;; Code:
 
+;; Silence byte-compiler
+(defvar ucs-normalize-combining-chars)  ; Defined in `ucs-normalize'
+(autoload 'slot-value "eieio")
+
 (defun s-trim-left (s)
   "Remove whitespace at the beginning of S."
   (save-match-data


### PR DESCRIPTION
Defer requiring `ucs-normalize` until variable `ucs-normalize-combining-chars` is used in function `s-reverse`.

As suggested in issue #77, this should result in `s.el` loading faster.