### PR TITLE
Add s-replace-regexp

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -458,4 +458,11 @@
     (s-blank-str? "\t") => t
     (s-blank-str? "t") => nil
     (s-blank-str? "\s") => t
-    (s-blank-str? " ") => t))
+    (s-blank-str? " ") => t)
+
+  (defexamples s-replace-regexp
+    (s-replace-regexp "[aeiou]" "!" "foo bar baz") => "f!! b!r b!z"
+    (s-replace-regexp "." "a" "foo bar baz") => "aaaaaaaaaaa"
+    (s-replace-regexp "mixedcase" "mixedcase" "ThIs iS MiXeDCaSE" t) => "ThIs iS mixedcase"
+    (s-replace-regexp "\\(h[ae]\\)" "\\1\\1" "hi he ha") => "hi hehe haha"
+    (s-replace-regexp "\\(h[ae]\\)" "\\1\\1" "hi he ha" nil t) => "hi \\1\\1 \\1\\1"))

--- a/s.el
+++ b/s.el
@@ -367,6 +367,8 @@ This is a simple wrapper around the built-in `string-match-p'."
   (declare (pure t) (side-effect-free t))
   (replace-regexp-in-string (regexp-quote old) new s t t))
 
+(defalias 's-replace-regexp 'replace-regexp-in-string)
+
 (defun s--aget (alist key)
   (declare (pure t) (side-effect-free t))
   (cdr (assoc-string key alist)))


### PR DESCRIPTION
**Don't merge this yet.**

@magnars: I need your guidance for the next points

Interface is quite different:

``` elisp
(s-replace OLD NEW S)
(s-replace-regexp REGEXP REP STRING &optional FIXEDCASE LITERAL SUBEXP START)
```

Do we want all the additional parameters? 

```
Replace all matches for REGEXP with REP in STRING.

Return a new string containing the replacements.

Optional arguments FIXEDCASE, LITERAL and SUBEXP are like the
arguments with the same names of function ‘replace-match’.  If START
is non-nil, start replacements at that index in STRING.

REP is either a string used as the NEWTEXT arg of ‘replace-match’ or a
function.  If it is a function, it is called with the actual text of each
match, and its value is used as the replacement text.  When REP is called,
the match data are the result of matching REGEXP against a substring
of STRING, the same substring that is the actual text of the match which
is passed to REP as its argument.

To replace only the first match (if any), make REGEXP match up to \'
and replace a sub-expression, e.g.
  (replace-regexp-in-string "\\(foo\\).*\\'" "bar" " foo foo" nil nil 1)
    => " bar foo"
```

TODO:

- [x] Need to add more examples.
- [x] Need to decide wether we want to limit the additional parameters to `s-replace-regexp`.
- [x] Need to decide wether to implement `s-replace-all-regexp`.