### PR TITLE
add s-count-matches-all

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -387,7 +387,7 @@
       (s-lex-format "${str1} and ${str2}"))
     => "this and that"
 
-    ;; Have a litteral \ in the replacement
+    ;; Have a literal \ in the replacement
     (let ((foo "Hello\\nWorld"))
       (s-lex-format "${foo}"))
     => "Hello\\nWorld"

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -396,7 +396,21 @@
   (defexamples s-count-matches
     (s-count-matches "a" "aba") => 2
     (s-count-matches "a" "aba" 0 2) => 1
-    (s-count-matches "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") => 2)
+    (s-count-matches "aa" "aaa") => 1
+    (s-count-matches "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") => 2
+    (s-count-matches "a" "aa" 2) => 1
+    (s-count-matches "a" "aaaa" 2 3) => 1)
+
+  (defexamples s-count-matches-all
+    (s-count-matches-all "a" "aba") => 2
+    (s-count-matches-all "a" "aba" 1 3) => 1
+    (s-count-matches-all "aa" "aaa") => 2
+    (s-count-matches-all "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") => 2
+    ;; Make sure we only count matches where the entire match is between start and end.
+    (s-count-matches-all "aaa" "aaaaaaaaa" 1 4) => 1
+
+    ;; s-count-matches-all should be one-indexed.
+    (s-count-matches-all "a" "aa" 2) => 1)
 
   (defexamples s-wrap
     (s-wrap "foo" "\"") => "\"foo\""

--- a/dev/examples.el
+++ b/dev/examples.el
@@ -395,7 +395,7 @@
 
   (defexamples s-count-matches
     (s-count-matches "a" "aba") => 2
-    (s-count-matches "a" "aba" 0 2) => 1
+    (s-count-matches "a" "aba" 1 3) => 1
     (s-count-matches "aa" "aaa") => 1
     (s-count-matches "\\w\\{2\\}[0-9]+" "ab1bab2frobinator") => 2
     (s-count-matches "a" "aa" 2) => 1

--- a/s.el
+++ b/s.el
@@ -664,13 +664,42 @@ interpolated with \"%S\"."
   "Count occurrences of `regexp' in `s'.
 
 `start', inclusive, and `end', exclusive, delimit the part of `s'
-to match. "
+to match.
+
+This function starts looking for the next match from the end of the
+previous match.  Hence, it ignores matches that overlap a previously
+found match.  To count overlapping matches, use
+`s-count-matches-all'."
   (declare (side-effect-free t))
   (save-match-data
     (with-temp-buffer
       (insert s)
       (goto-char (point-min))
       (count-matches regexp (or start 1) (or end (point-max))))))
+
+(defun s-count-matches-all (regexp s &optional start end)
+  "Count occurrences of `regexp' in `s'.
+
+`start', inclusive, and `end', exclusive, delimit the part of `s'
+to match.
+
+This function starts looking for the next match from the second
+character of the previous match.  Hence, it counts matches that
+overlap a previously found match.  To ignore matches that overlap a
+previously found match, use `s-count-matches'."
+  (declare (side-effect-free t))
+  (let* ((anchored-regexp (format "^%s" regexp))
+         (match-count 0)
+         (i 0)
+         (narrowed-s (substring s
+                                (when start (1- start))
+                                (when end (1- end)))))
+    (save-match-data
+      (while (< i (length narrowed-s))
+        (when (s-matches? anchored-regexp (substring narrowed-s i))
+          (setq match-count (1+ match-count)))
+        (setq i (1+ i))))
+    match-count))
 
 (defun s-wrap (s prefix &optional suffix)
   "Wrap string S with PREFIX and optionally SUFFIX.

--- a/s.el
+++ b/s.el
@@ -663,8 +663,9 @@ interpolated with \"%S\"."
 (defun s-count-matches (regexp s &optional start end)
   "Count occurrences of `regexp' in `s'.
 
-`start', inclusive, and `end', exclusive, delimit the part of `s'
-to match.
+`start', inclusive, and `end', exclusive, delimit the part of `s' to
+match.  `start' and `end' are both indexed starting at 1; the initial
+character in `s' is index 1.
 
 This function starts looking for the next match from the end of the
 previous match.  Hence, it ignores matches that overlap a previously
@@ -680,8 +681,9 @@ found match.  To count overlapping matches, use
 (defun s-count-matches-all (regexp s &optional start end)
   "Count occurrences of `regexp' in `s'.
 
-`start', inclusive, and `end', exclusive, delimit the part of `s'
-to match.
+`start', inclusive, and `end', exclusive, delimit the part of `s' to
+match.  `start' and `end' are both indexed starting at 1; the initial
+character in `s' is index 1.
 
 This function starts looking for the next match from the second
 character of the previous match.  Hence, it counts matches that


### PR DESCRIPTION
From a discussion in #120, adds a new function `s-count-matches-all`, which willl count overlapping matches of a regexp in a string. This also adds tests for that function, and some for `s-count-matches` to make obvious the difference.

It also updates the docstring for `s-count-matches` to specify that that function is 1-indexed, and fixes a typo in a comment.

Note that part of the docstrings that talk about whether the functions count overlapping matches is taken from Emacs's `count-matches`. If that's not ok, let me know and I'll write up something new.