### PR TITLE
s-truncate: Allow custom ellipsis string

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -55,7 +55,9 @@
   (defexamples s-truncate
     (s-truncate 6 "This is too long") => "Thi..."
     (s-truncate 16 "This is also too long") => "This is also ..."
-    (s-truncate 16 "But this is not!") => "But this is not!")
+    (s-truncate 16 "But this is not!") => "But this is not!"
+    (s-truncate 6 "Lorem ipsum" "…") => "Lorem…"
+    (s-truncate 9000 "Lorem ipsum" "…") => "Lorem ipsum")
 
   (defexamples s-left
     (s-left 3 "lib/file.js") => "lib"

--- a/s.el
+++ b/s.el
@@ -196,11 +196,18 @@ See also `s-split'."
   (declare (pure t) (side-effect-free t))
   (s-chop-suffixes '("\n" "\r") s))
 
-(defun s-truncate (len s)
-  "If S is longer than LEN, cut it down to LEN - 3 and add ... at the end."
+(defun s-truncate (len s &optional ellipsis)
+  "If S is longer than LEN, cut it down and add ELLIPSIS to the end.
+
+The resulting string, including ellipsis, will be LEN characters
+long.
+
+When not specified, ELLIPSIS defaults to ‘...’."
   (declare (pure t) (side-effect-free t))
+  (unless ellipsis
+    (setq ellipsis "..."))
   (if (> (length s) len)
-      (format "%s..." (substring s 0 (- len 3)))
+      (format "%s%s" (substring s 0 (- len (length ellipsis))) ellipsis)
     s))
 
 (defun s-word-wrap (len s)


### PR DESCRIPTION
Depending on tastes, users might prefer their ellipses to have a form such as
‘foo..’ or ‘foo…’, which we now support.