### PR TITLE
use while loop in s-slice-at

### DIFF
--- a/s.el
+++ b/s.el
@@ -513,14 +513,17 @@ When START is non-nil the search will start at that index."
 (defun s-slice-at (regexp s)
   "Slices S up at every index matching REGEXP."
   (declare (side-effect-free t))
-  (if (= 0 (length s)) (list "")
-    (save-match-data
-      (let (i)
-        (setq i (string-match regexp s 1))
-        (if i
-            (cons (substring s 0 i)
-                  (s-slice-at regexp (substring s i)))
-          (list s))))))
+  (let (ss)
+    (while (not (string-empty-p s))
+      (save-match-data
+        (let (i)
+          (setq i (string-match regexp s 1))
+          (if i
+              (setq ss (cons (substring s 0 i) ss)
+                    s (substring s i))
+            (setq ss (cons s ss)
+                  s "")))))
+    (nreverse ss)))
 
 (defun s-split-words (s)
   "Split S into list of words."

--- a/s.el
+++ b/s.el
@@ -513,17 +513,18 @@ When START is non-nil the search will start at that index."
 (defun s-slice-at (regexp s)
   "Slices S up at every index matching REGEXP."
   (declare (side-effect-free t))
-  (let (ss)
-    (while (not (string-empty-p s))
-      (save-match-data
-        (let (i)
-          (setq i (string-match regexp s 1))
-          (if i
-              (setq ss (cons (substring s 0 i) ss)
-                    s (substring s i))
-            (setq ss (cons s ss)
-                  s "")))))
-    (nreverse ss)))
+  (if (s-blank? s)
+      (list s)
+    (let (ss)
+      (while (not (s-blank? s))
+        (save-match-data
+          (let ((i (string-match regexp s 1)))
+            (if i
+                (setq ss (cons (substring s 0 i) ss)
+                      s (substring s i))
+              (setq ss (cons s ss)
+                    s "")))))
+      (nreverse ss))))
 
 (defun s-split-words (s)
   "Split S into list of words."


### PR DESCRIPTION
hi, I've made this change because I was hitting elisp's recursion limit because of `s-slice-at`. in my admittedly poor benchmarks, it runs faster even though I reverse the result in the end.

I also changed the `(= 0 (length s))` test to `s-blank?`, because calculating the length at every iteration is probably wasteful (unless the byte compiler is smarter than I imagine it to be!)

I left the `(declare (side-effect-free t))` because some other similar functions also have it, but I can't seem to find any documentation on it, except for the ones mentioned in this [reddit thread](https://www.reddit.com/r/emacs/comments/6qa6tr/optimising_dashel/).