### PR TITLE
Improve the performance of s-shared-start

### DIFF
--- a/s.el
+++ b/s.el
@@ -164,12 +164,8 @@ See also `s-split'."
 (defun s-shared-start (s1 s2)
   "Returns the longest prefix S1 and S2 have in common."
   (declare (pure t) (side-effect-free t))
-  (let ((search-length (min (length s1) (length s2)))
-        (i 0))
-    (while (and (< i search-length)
-                (= (aref s1 i) (aref s2 i)))
-      (setq i (1+ i)))
-    (substring s1 0 i)))
+  (let ((cmp (compare-strings s1 0 (length s1) s2 0 (length s2))))
+    (if (eq cmp t) s1 (substring s1 0 (1- (abs cmp))))))
 
 (defun s-shared-end (s1 s2)
   "Returns the longest suffix S1 and S2 have in common."


### PR DESCRIPTION
This yields a 2-3x speedup on short strings and 5-15x speedup on longer ones on
my machine.  I haven't done in-the-wild benchmarking because I don't currently use `s.el`, but I noticed this while reading the implementation.  Here's a mico-benchmark:

```elisp
(defvar ~/s1 "/home/clement/.emacs.d/.cask/28.0/bootstrap/s-20180406.808/s.el")
(defvar ~/s2 "/home/clement/.emacs.d/.cask/28.0/bootstrap/commander-20140120.1852/")
(benchmark-run-compiled 100000 (old-s-shared-start ~/s1 ~/s2))
;; Right after GC: (1.114678701 0 0.0); Normal use: (1.2542185909999999 1 0.13476934700000243)
(benchmark-run-compiled 100000 (new-s-shared-start ~/s1 ~/s2))
;; Right after GC: (0.072596075 0 0.0); Normal use: (0.22450463 1 0.1343407259999907) 
```

A similar trick could be used for s-shared-end, but I don't know of a way to do it without reversing the input strings (it's still ~2x faster, but it allocates, so the benefit is less clear-cut).

Do you need an update to the contributors list as well for the PR?
Also, I have copyright papers for Emacs on file, if that's needed.
