### PR TITLE
Enable lexical-binding

### DIFF
--- a/s.el
+++ b/s.el
@@ -1,4 +1,4 @@
-;;; s.el --- The long lost Emacs string manipulation library.
+;;; s.el --- The long lost Emacs string manipulation library. -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012-2015 Magnar Sveen
 
@@ -481,9 +481,8 @@ SUBEXP-DEPTH is 0 by default."
     (let ((pos 0) result)
       (while (and (string-match regexp string pos)
                   (< pos (length string)))
-        (let ((m (match-end subexp-depth)))
-          (push (cons (match-beginning subexp-depth) (match-end subexp-depth)) result)
-          (setq pos (match-end 0))))
+        (push (cons (match-beginning subexp-depth) (match-end subexp-depth)) result)
+        (setq pos (match-end 0)))
       (nreverse result))))
 
 (defun s-match (regexp s &optional start)


### PR DESCRIPTION
I wonder why lexical binding is not enabled for s.el? Even with the setting s.el will stay compatible with Emacs older than version 24 (see also https://github.com/magnars/s.el/issues/132).