### PR TITLE
s-trim-right: fix declare position

### DIFF
--- a/s.el
+++ b/s.el
@@ -41,8 +41,8 @@
 
 (defun s-trim-right (s)
   "Remove whitespace at the end of S."
+  (declare (pure t) (side-effect-free t))
   (save-match-data
-    (declare (pure t) (side-effect-free t))
     (if (string-match "[ \t\n\r]+\\'" s)
         (replace-match "" t t s)
       s)))


### PR DESCRIPTION
Hello

As noted by @dr-scsi in https://github.com/magnars/s.el/issues/143 the `(declare …)` form has to be placed just at the beginning of the body of the function to be effective.

Thanks