### PR TITLE
Fix #138 - s-replace-all

### DIFF
--- a/dev/examples.el
+++ b/dev/examples.el
@@ -283,7 +283,8 @@
 
   (defexamples s-replace-all
     (s-replace-all '(("lib" . "test") ("file" . "file_test")) "lib/file.js") => "test/file_test.js"
-    (s-replace-all '(("lib" . "test") ("test" . "lib")) "lib/test.js") => "test/lib.js")
+    (s-replace-all '(("lib" . "test") ("test" . "lib")) "lib/test.js") => "test/lib.js"
+    (s-replace-all '(("FOO" . "bar") ("FLOO" . "bah")) "FOO BLOO foo") => "bar BLOO foo")
 
   (defexamples s-downcase
     (s-downcase "ABC") => "abc")

--- a/s.el
+++ b/s.el
@@ -399,20 +399,17 @@ This is a simple wrapper around the built-in `string-match-p'."
 (defalias 's-replace-regexp 'replace-regexp-in-string)
 
 (defun s--aget (alist key)
+  "Get the value of KEY in ALIST."
   (declare (pure t) (side-effect-free t))
   (cdr (assoc-string key alist)))
 
 (defun s-replace-all (replacements s)
   "REPLACEMENTS is a list of cons-cells. Each `car` is replaced with `cdr` in S."
   (declare (pure t) (side-effect-free t))
-  (replace-regexp-in-string
-   (regexp-opt (mapcar 'car replacements))
-   (lambda (it)
-     (let ((replacement (s--aget replacements it)))
-       (if (null replacement)
-           it
-         replacement)))
-   s t t))
+  (let ((case-fold-search nil))
+   (replace-regexp-in-string (regexp-opt (mapcar 'car replacements))
+                             (lambda (it) (s--aget replacements it))
+                             s t t)))
 
 (defun s-downcase (s)
   "Convert S to lower case.

--- a/s.el
+++ b/s.el
@@ -405,9 +405,14 @@ This is a simple wrapper around the built-in `string-match-p'."
 (defun s-replace-all (replacements s)
   "REPLACEMENTS is a list of cons-cells. Each `car` is replaced with `cdr` in S."
   (declare (pure t) (side-effect-free t))
-  (replace-regexp-in-string (regexp-opt (mapcar 'car replacements))
-                            (lambda (it) (s--aget replacements it))
-                            s t t))
+  (replace-regexp-in-string
+   (regexp-opt (mapcar 'car replacements))
+   (lambda (it)
+     (let ((replacement (s--aget replacements it)))
+       (if (null replacement)
+           it
+         replacement)))
+   s t t))
 
 (defun s-downcase (s)
   "Convert S to lower case.


### PR DESCRIPTION
In #138 errors were thrown by the replacer
function finding a nil replacement.

We solve it by returning found the original text instead of a
replacement, when the replacement value is nil.